### PR TITLE
ability to specify additional dependencies for cache hash creation

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -54,8 +54,8 @@ Cp.loadCacheFromDisk = function () {
   return cache;
 };
 
-Cp.get = function (source, options) {
-  var cacheHash = util.deepHash(meteorBabelVersion, source, options);
+Cp.get = function (source, options, deps) {
+  var cacheHash = util.deepHash(meteorBabelVersion, source, options, deps);
   var cacheFile = cacheHash + ".json";
   var fullCacheFile = path.join(this.dir, cacheFile);
   var result;

--- a/index.js
+++ b/index.js
@@ -35,12 +35,12 @@ function parse(source) {
 }
 exports.parse = parse;
 
-exports.compile = function compile(source, options) {
+exports.compile = function compile(source, options, deps) {
   options = options || getDefaultOptions();
   if (! compileCache) {
     setCacheDir();
   }
-  return compileCache.get(source, options);
+  return compileCache.get(source, options, deps);
 };
 
 function setCacheDir(cacheDir) {


### PR DESCRIPTION
Will be needed for at least a hash on a user's custom `.babelrc` and maybe other things in the future.

Example usage is as expected (sorry, a few other things snuck into this commit):
https://github.com/gadicc/meteor-react-hotloader/commit/cb2fd8a387d1427340e8aa560728d1a12300b3d0

We can discuss more in https://github.com/meteor/meteor/issues/6351.

Update: e.g. need to hash on `process.env.BABEL_ENV || process.env.NODE_ENV` too, since `.babelrc` contains env-specific configs.  Could use to pass an optional preferential `sourceHash` to speed up hashing (as per #8)
