### PR TITLE
remove meteor preset from defaults, so order can be set in .babelrc

### DIFF
--- a/options.js
+++ b/options.js
@@ -8,7 +8,7 @@ exports.getDefaults = function getDefaults(features) {
     // classes, computed properties, modules, for-of, and template literals.
     // Basically all the transformers that support "loose".
     // http://babeljs.io/docs/usage/loose/
-    presets: [require("babel-preset-meteor")],
+    presets: [],  // meteor preset must now be specified in .babelrc
     plugins: []
   };
 


### PR DESCRIPTION
(to discuss post-1.3)

If you want to use, say, the `transform-decorator` plugin, it has to be loaded before the `meteor` preset.  But not just for that reason, I think this is the right way to go regardless, since:
1. Consistent babel settings for non-Meteor tools, e.g. wallaby.
2. Ability to fine tune exact plugins rather than use the entire Meteor preset, if someone really wants.

So now in meteor-react-hotloader's babel-compiler at least we:
1. Create `.babelrc` if it doesn't already exist with a skeleton
2. Assert that `{ presets: "meteor" }` exists.

i.e. https://github.com/gadicc/meteor-react-hotloader/blob/master/babel-compiler-hot/babelrc.js

`meteor-babel` / `babel-compiler` will still conditionally add the `jscript` plugins based on target, we'll have to think about that.  For now I left `react` in there too, even though it's now used for everything and should probably be in `.babelrc` too.
