### PR TITLE
Fix source map generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ function compile(source, options) {
   // destroy unreliable token information. Don't worry; Babel can cope.
   delete ast.tokens;
 
-  let inputSourceMap;
   const babelCore = require("babel-core");
   let result;
 
@@ -46,21 +45,10 @@ function compile(source, options) {
     optionsCopy.presets = presets;
     optionsCopy.ast = true;
 
-    if (inputSourceMap) {
-      optionsCopy.inputSourceMap = inputSourceMap;
-    }
-
     const result = babelCore.transformFromAst(ast, source, optionsCopy);
-
-    source = result.code;
-    ast = result.ast;
 
     if (options.ast === false) {
       delete result.ast;
-    }
-
-    if (result.map) {
-      inputSourceMap = result.map;
     }
 
     return result;

--- a/index.js
+++ b/index.js
@@ -38,12 +38,17 @@ function compile(source, options) {
   const babelCore = require("babel-core");
   let result;
 
-  function transform(presets) {
+  function transform(presets, generateCode) {
     const optionsCopy = Object.assign({}, options);
 
     delete optionsCopy.plugins;
     optionsCopy.presets = presets;
     optionsCopy.ast = true;
+
+    if (! generateCode) {
+      optionsCopy.code = false;
+      optionsCopy.sourceMaps = false;
+    }
 
     const result = babelCore.transformFromAst(ast, source, optionsCopy);
 
@@ -62,7 +67,7 @@ function compile(source, options) {
   }
 
   if (options.presets) {
-    result = transform(options.presets);
+    result = transform(options.presets, true);
   }
 
   return result;

--- a/index.js
+++ b/index.js
@@ -61,9 +61,12 @@ function compile(source, options) {
 
   if (options.plugins &&
       options.plugins.length > 0) {
-    result = transform([{
-      plugins: options.plugins
-    }]);
+    result = transform(
+      [{ plugins: options.plugins }],
+      // If there are no options.presets, then this is the final transform
+      // call, so make sure we generate code.
+      ! options.presets
+    );
   }
 
   if (options.presets) {


### PR DESCRIPTION
This PR fixes source map generation to resolve one of the debugging issues described in meteor/meteor#8611.

The source maps that are generated by `compile` are wrong if at least one Babel plugin is included in the `options` object (see https://github.com/meteor/meteor/issues/8611#issuecomment-313872380). I'm not really sure why the current implementation doesn't work but it looks like it's a problem with Babel's `inputSourceMap` option. Instead of using an intermediate source map, I think it's fine to transform the AST twice and let Babel generate the source map from the final AST only. Another benefit is that `compile` doesn't have to generate code twice (once for each pass) anymore.

I have tested this change with a few combinations of Babel plugins and presets and `compile` always created a correct source map.