### PR TITLE
Make it easy to get default Babel options for Node 8+.

### DIFF
--- a/options.js
+++ b/options.js
@@ -1,10 +1,12 @@
-var babelPresetMeteor = require("babel-preset-meteor");
-var reifyPlugin = require("babel-plugin-transform-es2015-modules-reify");
-var strictModulesPluginFactory =
+"use strict";
+
+const babelPresetMeteor = require("babel-preset-meteor");
+const reifyPlugin = require("babel-plugin-transform-es2015-modules-reify");
+const strictModulesPluginFactory =
   require("babel-plugin-transform-es2015-modules-commonjs");
 
-var babelModulesPlugin = [function () {
-  var plugin = strictModulesPluginFactory.apply(this, arguments);
+const babelModulesPlugin = [function () {
+  const plugin = strictModulesPluginFactory.apply(this, arguments);
   // Since babel-preset-meteor uses an exact version of the
   // babel-plugin-transform-es2015-modules-commonjs transform (6.8.0), we
   // can be sure this plugin.inherits property is indeed the
@@ -25,7 +27,7 @@ exports.getDefaults = function getDefaults(features) {
     return getDefaultsForNode8(features);
   }
 
-  var combined = {
+  const combined = {
     presets: [babelPresetMeteor],
     plugins: [
       [reifyPlugin, {
@@ -135,7 +137,7 @@ function getDefaultsForNode8(features) {
 }
 
 exports.getMinifierDefaults = function getMinifierDefaults(features) {
-  var options = {
+  const options = {
     // Generate code in loose mode
     compact: false,
     // Don't generate a source map, we do that during compilation

--- a/plugins/async-await.js
+++ b/plugins/async-await.js
@@ -1,41 +1,64 @@
+"use strict";
+
 module.exports = function (babel) {
-  var t = babel.types;
+  const t = babel.types;
 
   return {
     visitor: {
-      Function: function (path) {
-        var node = path.node;
-        if (! node.async) {
-          return;
-        }
+      Function: {
+        exit: function (path) {
+          const node = path.node;
+          if (! node.async) {
+            return;
+          }
 
-        node.async = false;
+          // The original function becomes a non-async function that
+          // returns a Promise.
+          node.async = false;
 
-        node.body = t.blockStatement([
-          t.expressionStatement(t.stringLiteral("use strict")),
-          t.returnStatement(
-            t.callExpression(
-              t.memberExpression(
-                t.identifier("Promise"),
-                t.identifier("asyncApply"),
-                false
-              ),
-              [
-                t.functionExpression(
-                  null, // anonymous
-                  node.params.slice(0),
-                  node.body
-                ),
-                t.thisExpression(),
-                t.identifier("arguments")
-              ]
+          const innerFn = t.functionExpression(
+            null, // anonymous
+            node.params.slice(0),
+            node.body
+          );
+
+          if (this.opts.useNativeAsyncAwait) {
+            // The inner function called by Promise.asyncApply should be
+            // async if we have native async/await support.
+            innerFn.async = true;
+          }
+
+          // Calling the async function with Promise.asyncApply is
+          // important to ensure that the part before the first await
+          // expression runs synchronously in its own Fiber, even when
+          // there is native support for async/await.
+          node.body = t.blockStatement([
+            t.expressionStatement(t.stringLiteral("use strict")),
+            t.returnStatement(
+              t.callExpression(
+                t.memberExpression(
+                  t.identifier("Promise"),
+                  t.identifier("asyncApply"),
+                  false
+                ), [
+                  innerFn,
+                  t.thisExpression(),
+                  t.identifier("arguments")
+                ]
+              )
             )
-          )
-        ]);
+          ]);
+        }
       },
 
       AwaitExpression: function (path) {
-        var node = path.node;
+        if (this.opts.useNativeAsyncAwait) {
+          // No need to transform await expressions if we have native
+          // support for them.
+          return;
+        }
+
+        const node = path.node;
         path.replaceWith(t.callExpression(
           t.memberExpression(
             t.identifier("Promise"),

--- a/plugins/async-await.js
+++ b/plugins/async-await.js
@@ -28,6 +28,11 @@ module.exports = function (babel) {
             innerFn.async = true;
           }
 
+          // If the original node was an arrow function, the inner
+          // function should be as well. However, the inner function
+          // should always be an expression, not a declaration.
+          innerFn.type = node.type.replace(/Declaration$/, "Expression");
+
           // Calling the async function with Promise.asyncApply is
           // important to ensure that the part before the first await
           // expression runs synchronously in its own Fiber, even when

--- a/plugins/async-await.js
+++ b/plugins/async-await.js
@@ -38,7 +38,6 @@ module.exports = function (babel) {
           // expression runs synchronously in its own Fiber, even when
           // there is native support for async/await.
           node.body = t.blockStatement([
-            t.expressionStatement(t.stringLiteral("use strict")),
             t.returnStatement(
               t.callExpression(
                 t.memberExpression(

--- a/plugins/async-await.js
+++ b/plugins/async-await.js
@@ -4,6 +4,7 @@ module.exports = function (babel) {
   const t = babel.types;
 
   return {
+    name: "transform-meteor-async-await",
     visitor: {
       Function: {
         exit: function (path) {

--- a/plugins/dynamic-import.js
+++ b/plugins/dynamic-import.js
@@ -3,6 +3,7 @@ module.exports = function () {
   var buildImport = template("module.dynamicImport(SOURCE)");
 
   return {
+    name: "transform-meteor-dynamic-import",
     inherits: require("babel-plugin-syntax-dynamic-import"),
     visitor: {
       CallExpression: function (path) {

--- a/test/register.js
+++ b/test/register.js
@@ -1,7 +1,9 @@
 var path = require("path");
 var meteorBabelTestPath = __dirname;
 var meteorBabelPath = path.dirname(meteorBabelTestPath);
+var nodeMajorVersion = parseInt(process.versions.node);
 var babelOptions = require("../options").getDefaults({
+  nodeMajorVersion,
   react: true,
   jscript: true
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,6 +6,7 @@ import {
 } from "./test-module";
 
 const hasOwn = Object.prototype.hasOwnProperty;
+const isNode8OrLater = parseInt(process.versions.node) >= 8;
 
 describe("meteor-babel", () => {
   import meteorBabel from "../index.js";
@@ -59,7 +60,8 @@ describe("meteor-babel", () => {
 });
 
 describe("Babel", function() {
-  it("es3.propertyLiterals", () => {
+  (isNode8OrLater ? xit : it)
+  ("es3.propertyLiterals", () => {
     function getCatch(value) {
       let obj = { catch: value };
       return obj.catch;
@@ -317,7 +319,8 @@ val = "zxcv";`;
     "function C("
   ];
 
-  it("jscript", function jscript() {
+  (isNode8OrLater ? xit : it)
+  ("jscript", function jscript() {
     let f = function f() {
       return f;
     };
@@ -332,7 +335,8 @@ val = "zxcv";`;
     assert.deepEqual(fns, expectedFns);
   });
 
-  it("for-in loop sanitization", function loop() {
+  (isNode8OrLater ? xit : it)
+  ("for-in loop sanitization", function loop() {
     Array.prototype.dummy = () => {};
 
     // Use the full version of sanitizeForInObject even though these tests


### PR DESCRIPTION
[Meteor 1.6](https://github.com/meteor/meteor/pull/8728#issue-232369984) will ship with Node 8, which has native support for virtually every standard ECMAScript feature, including `async`/`await` (but notably excluding `import`/`export`, which we will continue to compile using [Reify](https://github.com/benjamn/reify#how-it-works)).

This pull request makes it simpler to get default options with Babel plugins appropriate for Node 8 (and later) by calling
```js
require("meteor-babel").getDefaultOptions({
  nodeMajorVersion: 8 // or 9, 10, ...
});
```
Note that this API is backwards-compatible with older versions of `meteor-babel`, because they will simply ignore the `features.nodeMajorVersion` property and continue returning options appropriate for Node 4.

Since these new options contain many fewer Babel plugins, we hope compilation times will be faster for server code (even though there is constant overhead from parsing &c. that hasn't changed), or at least that the generated code is easier to read and debug.

It was tempting to use [`babel-preset-env`](https://www.npmjs.com/package/babel-preset-env) to help with this, but the fact that Meteor ships with one version of Node, together with the need for custom plugins, made that somewhat less appealing. I'm still open to it, though, if it really simplifies things.