### PR TITLE
Allow configuring keepFnName for babel-minify.

### DIFF
--- a/options.js
+++ b/options.js
@@ -206,7 +206,7 @@ function getDefaultsForNode8(features) {
   return finish(presets);
 }
 
-exports.getMinifierDefaults = function getMinifierDefaults(features) {
+exports.getMinifierDefaults = function getMinifierDefaults({ inlineNodeEnv, keepFnName = false } = {}) {
   const options = {
     // Generate code in loose mode
     compact: false,
@@ -220,16 +220,14 @@ exports.getMinifierDefaults = function getMinifierDefaults(features) {
     plugins: [],
     // Only include the minifier plugins, since we've already compiled all
     // the ECMAScript syntax we want.
-    presets: [require("babel-preset-minify")]
+    presets: [[require("babel-preset-minify"), { keepClassName: keepFnName, keepFnName }]]
   };
 
-  if (features) {
-    if (features.inlineNodeEnv) {
-      options.plugins.push([
-        require("./plugins/inline-node-env.js"),
-        { nodeEnv: features.inlineNodeEnv }
-      ]);
-    }
+  if (inlineNodeEnv) {
+    options.plugins.push([
+      require("./plugins/inline-node-env.js"),
+      { nodeEnv: inlineNodeEnv }
+    ]);
   }
 
   return options;


### PR DESCRIPTION
This PR allows other packages to configure meteor-babel to keepFnName during minification and it defaults to the old behaviour of not keeping them.

Some of the packages that I'm using require class names to be kept during minification. However, since transpilation is performed, it's not possible to keep just class names, therefore I have to keep both class and function names. When I keep both, everything works fine.