### PR TITLE
Use actual TypeScript instead of @babel/preset-typescript.

### DIFF
--- a/options.js
+++ b/options.js
@@ -65,7 +65,6 @@ exports.getDefaults = function getDefaults(features) {
     }
 
     maybeAddReactPlugins(features, combined);
-    maybeAddTypeScriptPreset(features, combined.presets);
 
     if (features && features.jscript) {
       combined.plugins.push(
@@ -75,7 +74,7 @@ exports.getDefaults = function getDefaults(features) {
     }
   }
 
-  return finish([combined]);
+  return finish(features, [combined]);
 };
 
 function maybeAddReactPlugins(features, options) {
@@ -86,12 +85,6 @@ function maybeAddReactPlugins(features, options) {
         loose: true
       }]
     );
-  }
-}
-
-function maybeAddTypeScriptPreset(features, presets) {
-  if (features && features.typescript) {
-    presets.push(require("@babel/preset-typescript"));
   }
 }
 
@@ -111,17 +104,16 @@ function getDefaultsForModernBrowsers(features) {
     }
 
     maybeAddReactPlugins(features, combined);
-    maybeAddTypeScriptPreset(features, combined.presets);
   }
 
-  return finish([combined]);
+  return finish(features, [combined]);
 }
 
 const parserOpts = require("reify/lib/parsers/babel.js").options;
 const util = require("./util.js");
 
-function finish(presets) {
-  return {
+function finish(features, presets) {
+  const options = {
     compact: false,
     sourceMaps: false,
     ast: false,
@@ -132,6 +124,14 @@ function finish(presets) {
     parserOpts: util.deepClone(parserOpts),
     presets: presets
   };
+
+  if (features && features.typescript) {
+    // This additional option will be consumed by the meteorBabel.compile
+    // function before the options are passed to Babel.
+    options.typescript = true;
+  }
+
+  return options;
 }
 
 function isObject(value) {
@@ -191,10 +191,9 @@ function getDefaultsForNode8(features) {
 
   if (! compileModulesOnly) {
     maybeAddReactPlugins(features, combined);
-    maybeAddTypeScriptPreset(features, combined.presets);
   }
 
-  return finish([combined]);
+  return finish(features, [combined]);
 }
 
 exports.getMinifierDefaults = function getMinifierDefaults(features) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -375,14 +375,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-syntax-typescript": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
-      "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
@@ -618,16 +610,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-typescript": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.0.tgz",
-      "integrity": "sha512-z3T4P70XJFUAHzLtEsmJ37BGVDj+55/KX8W8TBSBF0qk0KLazw8xlwVcRHacxNPgprzTdI4QWW+2eS6bTkQbCA==",
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.5.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-typescript": "^7.2.0"
-      }
-    },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
@@ -648,15 +630,6 @@
         "@babel/plugin-transform-react-jsx": "^7.0.0",
         "@babel/plugin-transform-react-jsx-self": "^7.0.0",
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
-      }
-    },
-    "@babel/preset-typescript": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
-      "integrity": "sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.3.2"
       }
     },
     "@babel/runtime": {
@@ -2257,6 +2230,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "typescript": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@babel/plugin-transform-modules-commonjs": "^7.5.0",
     "@babel/plugin-transform-runtime": "^7.5.0",
     "@babel/preset-react": "^7.0.0",
-    "@babel/preset-typescript": "^7.3.3",
     "@babel/runtime": "^7.5.0",
     "@babel/template": "^7.4.4",
     "@babel/traverse": "^7.5.0",
@@ -46,7 +45,8 @@
     "convert-source-map": "^1.6.0",
     "lodash": "^4.17.11",
     "meteor-babel-helpers": "0.0.3",
-    "reify": "^0.20.12"
+    "reify": "^0.20.12",
+    "typescript": "^3.5.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "7.4.4",

--- a/test/class-properties.ts
+++ b/test/class-properties.ts
@@ -1,4 +1,7 @@
+const enum TestResult { PASS, FAIL }
+
 export class Test {
   public property: number = 1234;
+  public result = TestResult.PASS;
   constructor(public value: string) {}
 }

--- a/test/react.tsx
+++ b/test/react.tsx
@@ -1,0 +1,3 @@
+export function Component() {
+  return <div>oyez</div>;
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -319,6 +319,16 @@ describe("meteor-babel", () => {
       "})(Test || module.runSetters(Test = {}));",
     ].join("\n"));
   });
+
+  it("can handle JSX syntax in .tsx files", () => {
+    const { Component } = require("./react.tsx");
+    assert.strictEqual(typeof Component, "function");
+    assert.strictEqual(String(Component), [
+      'function Component() {',
+      '  return React.createElement("div", null, "oyez");',
+      '}',
+    ].join("\n"));
+  });
 });
 
 describe("Babel", function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -288,8 +288,36 @@ describe("meteor-babel", () => {
     const tsTest = new Test("asdf");
     assert.strictEqual(tsTest.property, 1234);
     assert.strictEqual(tsTest.value, "asdf");
+    assert.strictEqual(typeof tsTest.result, "number");
     const jsTest = new (class { foo = 42 });
     assert.strictEqual(jsTest.foo, 42);
+  });
+
+  it("can compile TypeScript syntax", () => {
+    const options = meteorBabel.getDefaultOptions({
+      typescript: true,
+    });
+
+    assert.strictEqual(options.typescript, true);
+
+    const result = meteorBabel.compile([
+      "export namespace Test {",
+      "  export const enabled = true;",
+      "}",
+    ].join("\n"), options);
+
+    assert.strictEqual(result.code, [
+      "module.export({",
+      "  Test: function () {",
+      "    return Test;",
+      "  }",
+      "});",
+      "var Test;",
+      "",
+      "(function (Test) {",
+      "  Test.enabled = true;",
+      "})(Test || module.runSetters(Test = {}));",
+    ].join("\n"));
   });
 });
 


### PR DESCRIPTION
Babel's TypeScript implementation has a few unfortunate caveats: https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats

Most notably, the lack of *full* support for namespaces is painful:
* https://github.com/babel/babel/issues/8244
* https://github.com/babel/babel/pull/9785

By precompiling TypeScript code with the actual TypeScript compiler, we can support features like namespaces without relying on Babel. Of course, Babel still handles everything after TypeScript syntax has been removed.