### PR TITLE
Add support for decorators and metadata reflection in TS

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,8 @@ function precompileTypeScript(result, options) {
         esModuleInterop: false,
         sourceMap: true,
         inlineSources: true,
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
       }
     });
   } catch (e) {


### PR DESCRIPTION
This PR adds decorators and metadata reflection support to `TypeScript` package. It doesn't affect existing users. So, libraries and frameworks like Angular, TypeORM and TypeGraphQL can be used with their decorators with the benefit of type reflection.

Suggestion: I think using `babel-typescript` is better than having multiple compilation process. So instead of dealing with `tsconfig`. People can use `babelrc` for enhancing TypeScript support with decorators and stuff. But this would need to remove `flow` plugins for `TS` files only due to the conflict of typing syntax.

