### PR TITLE
Add support for decorators and metadata reflection in TS

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,8 @@ function precompileTypeScript(result, options) {
         esModuleInterop: false,
         sourceMap: true,
         inlineSources: true,
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
       }
     });
   } catch (e) {


### PR DESCRIPTION
This PR adds decorators and metadata reflection support to TypeScript package. It doesn't affect existing users. So, libraries and frameworks like Angular, TypeORM and TypeGraphQL can be used with their decorators with the benefit of type reflection.

As decorators are still on [Stage 2](https://github.com/tc39/proposals/#stage-2) we are going to recommend in the release notes of Meteor to use it aware that maybe you are going to get breaking changes in the future but we don't want to hold back people that are aware of this but want to use decorators today.

This PR was created because https://github.com/meteor/babel/pull/28 was failing on Travis.