### PR TITLE
Allow to disable sourceMap generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function compile(source, options) {
     }];
 
     optionsCopy.presets = presets;
-    optionsCopy.sourceMaps = options.sourceMaps !== false;
+    optionsCopy.sourceMaps = options.soruceMap !== false && options.sourceMaps !== false;
     if (optionsCopy.sourceMaps && result.map) {
       optionsCopy.inputSourceMap = result.map;
     }

--- a/index.js
+++ b/index.js
@@ -103,8 +103,8 @@ function compile(source, options) {
     }];
 
     optionsCopy.presets = presets;
-    optionsCopy.sourceMaps = true;
-    if (result.map) {
+    optionsCopy.sourceMaps = options.sourceMaps !== false;
+    if (optionsCopy.sourceMaps && result.map) {
       optionsCopy.inputSourceMap = result.map;
     }
 

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function compile(source, options) {
     }];
 
     optionsCopy.presets = presets;
-    optionsCopy.sourceMaps = options.soruceMap !== false && options.sourceMaps !== false;
+    optionsCopy.sourceMaps = options.sourceMap !== false && options.sourceMaps !== false;
     if (optionsCopy.sourceMaps && result.map) {
       optionsCopy.inputSourceMap = result.map;
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -93,6 +93,7 @@ describe("meteor-babel", () => {
     babelOptions.plugins = [
       require("@babel/plugin-transform-arrow-functions"),
     ];
+    babelOptions.sourceMaps = true;
 
     const result = meteorBabel.compile(source, babelOptions);
 


### PR DESCRIPTION
@filipenevola This is an updated version of: https://github.com/meteor/babel/pull/23 . Which I think is still valuable for some plugins that use meteor-babel